### PR TITLE
feat: Add responsive grid layout for videos

### DIFF
--- a/responsive_main.css
+++ b/responsive_main.css
@@ -310,3 +310,37 @@
     page-break-after: avoid;
   }
 }
+
+/* =========================
+   VIDEO GRID
+   ========================= */
+
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+  border-radius: 15px;
+  box-shadow: var(--shadow);
+  transition: transform 0.3s ease;
+}
+
+.video-wrapper:hover {
+  transform: scale(1.05);
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
This commit introduces a responsive grid layout for the videos on the 'hypnose.html' and 'apropos.html' pages.

The new layout uses CSS Grid to display the videos in a more visually appealing way, with the number of columns adjusting automatically to the screen size.

- Added CSS rules for `.video-grid` and `.video-wrapper`.
- The videos now have a 16:9 aspect ratio and are responsive.
- Added a subtle shadow and hover effect to the video wrappers for better user experience.