### PR TITLE
Fix: Correct button text color in contact section

### DIFF
--- a/style_v2.css
+++ b/style_v2.css
@@ -571,14 +571,14 @@ body {
   margin: 20px 0;
 }
 
-.contact a {
+.contact a:not(.btn) {
   color: var(--accent-color);
   text-decoration: none;
   font-weight: 600;
   transition: all 0.3s ease;
 }
 
-.contact a:hover {
+.contact a:not(.btn):hover {
   color: var(--button-hover);
   text-decoration: underline;
 }


### PR DESCRIPTION
The text color of the 'Donner un avis' and 'Prendre rendez-vous' buttons was being overridden by a more general rule for links in the contact section. This change uses the `:not(.btn)` pseudo-class to exclude buttons from this rule, ensuring they have the correct text color as defined by the `.btn` class.