### PR TITLE
Feat: Update Hypnose page with magazine-style layout

### DIFF
--- a/hypnose.html
+++ b/hypnose.html
@@ -131,32 +131,45 @@
 </div>
     </section>
   
-<section class="container">
-   <h3>l'hypnothérapie</h3>
-      <div class="square-img-grid">
-          <div class="square-img-wrapper">
-          <img src="img/cabinet/ai_approfondissement.webp" alt="Sujet symbolique positif pour phobies" loading="lazy">
-          <div>
-            <h5>Phase d'approfondissement</h5>
-            <p>Une étape pour entrer plus profondément dans l'expérience.</p>
-          </div>
-        </div>
-       <div class="square-img-wrapper">
-          <img src="img/cabinet/ai_dors.webp" alt="Personne assise dans un parc, yeux fermés, respiration profonde" loading="lazy">
-          <div>
-            <h5>Dord!</h5>
-            <p>On ne dort pas vraiment, on reste toujours concient.</p>
-          </div>
-        </div>
-       <div class="square-img-wrapper">
-          <img src="img/cabinet/ai_tiens_main.webp" alt="Personne franchissant une ligne d'arrivée, signe de réussite" loading="lazy">
-          <div>
-            <h5>Jeux de perceptifité</h5>
-            <p>Quelques jeux ludiques, pour faire ressentir l'hypnose.</p>
-          </div>
-        </div>
-      </div>
-    </section>
+<section class="container clearfix">
+  <h3>L'hypnothérapie en cabinet</h3>
+
+  <h4>L’hypnose moderne en cabinet : un espace pour avancer</h4>
+  <p>
+    Pousser la porte d’un cabinet d’hypnothérapie, c’est s’offrir un moment à soi, dans un cadre calme et sécurisant. Ici, il n’est pas question de spectacle, mais d’un accompagnement personnalisé, basé sur l’écoute et le respect de vos besoins.
+  </p>
+
+  <img src="img/cabinet/ai_approfondissement.webp" alt="Phase d'approfondissement en hypnothérapie" class="float-right" loading="lazy" style="width: 300px; height: auto;">
+
+  <h4>Comment se déroule une séance ?</h4>
+  <p>
+    Chaque séance commence par un temps d’échange : nous prenons le temps de clarifier vos attentes, vos objectifs et de répondre à vos questions.
+    Puis, grâce à des techniques d’hypnose modernes et douces, vous êtes guidé vers un état de détente naturelle. Dans cet état, vous restez conscient et maître de vous-même, tout en étant plus réceptif aux suggestions positives.
+    En fin de séance, nous prenons quelques minutes pour partager vos ressentis et consolider les bénéfices.
+  </p>
+
+  <img src="img/cabinet/ai_dors.webp" alt="Détente profonde en séance d'hypnose" class="float-left" loading="lazy" style="width: 300px; height: auto;">
+
+  <h4>Une méthode concrète et efficace</h4>
+  <p>
+    L’hypnose en cabinet s’adresse à toute personne désireuse de changer durablement. C’est une approche brève et orientée solutions : quelques séances suffisent souvent pour constater des évolutions significatives.
+  </p>
+  <p>Elle peut vous aider à :</p>
+  <ul>
+    <li>apaiser le stress et les émotions,</li>
+    <li>surmonter une phobie ou un blocage,</li>
+    <li>vous libérer d’une dépendance (tabac, grignotage…),</li>
+    <li>retrouver confiance en vous,</li>
+    <li>améliorer votre sommeil et votre énergie au quotidien.</li>
+  </ul>
+
+  <img src="img/cabinet/ai_tiens_main.webp" alt="Accompagnement personnalisé en hypnose" class="float-right" loading="lazy" style="width: 300px; height: auto;">
+
+  <h4>Un accompagnement sur mesure</h4>
+  <p>
+    Chaque parcours est unique : je m’adapte à votre rythme, à vos besoins et à votre personnalité. Mon rôle est de vous guider vers vos propres ressources, afin que vous puissiez retrouver équilibre, confiance et liberté intérieure.
+  </p>
+</section>
 
   
  <section class="container">

--- a/style_v2.css
+++ b/style_v2.css
@@ -908,6 +908,32 @@ footer {
 }
 
 /* =========================
+   ARTICLE LAYOUT
+   ========================= */
+.float-left {
+  float: left;
+  margin: 0 20px 10px 0;
+  max-width: 40%;
+  border-radius: 15px;
+  box-shadow: var(--shadow);
+}
+
+.float-right {
+  float: right;
+  margin: 0 0 10px 20px;
+  max-width: 40%;
+  border-radius: 15px;
+  box-shadow: var(--shadow);
+}
+
+/* Clearfix for floated content */
+.clearfix::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/* =========================
    RESPONSIVE DESIGN
    ========================= */
 


### PR DESCRIPTION
This commit revamps the "l'hypnothérapie" section on the `hypnose.html` page.

- Replaces the previous image grid with a new long-form text provided by the user.
- Integrates the existing images into the text flow to create a "magazine-style" article layout, as requested.
- Adds new CSS utility classes (`.float-left`, `.float-right`, `.clearfix`) to `style_v2.css` to support the new layout and allow for future use.
- Improves accessibility by adding more descriptive alt text to the images.