### PR TITLE
Fix: Prevent theme flash on initial load

### DIFF
--- a/apropos.html
+++ b/apropos.html
@@ -17,6 +17,19 @@
   <link rel="stylesheet" href="style_form.css" />
   <link rel="stylesheet" href="responsive_main.css" />
   <script src="https://kit.fontawesome.com/2f363087de.js" crossorigin="anonymous"></script>
+  <script>
+    // Gestion des thèmes
+    function setTheme(theme) {
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+
+    // Charger thème depuis localStorage
+    (function () {
+      const savedTheme = localStorage.getItem("theme") || "theme1";
+      setTheme(savedTheme);
+    })();
+  </script>
 </head>
 <body>
   <!-- NAVBAR -->
@@ -222,18 +235,6 @@
   </footer>
 
   <script>
-    // Gestion des thèmes
-    function setTheme(theme) {
-      localStorage.setItem("theme", theme);
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-
-    // Charger thème depuis localStorage
-    (function () {
-      const savedTheme = localStorage.getItem("theme") || "theme1";
-      setTheme(savedTheme);
-    })();
-
     // SCRIPT HAMBURGER 
     document.getElementById('hamburger').addEventListener('click', function () {
       document.getElementById('nav-links').classList.toggle('show');

--- a/contact.html
+++ b/contact.html
@@ -17,6 +17,19 @@
   <link rel="stylesheet" href="style_form.css" />
   <link rel="stylesheet" href="responsive_main.css" />
   <script src="https://kit.fontawesome.com/2f363087de.js" crossorigin="anonymous"></script>
+  <script>
+    // Gestion des thèmes
+    function setTheme(theme) {
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+
+    // Charger thème depuis localStorage
+    (function () {
+      const savedTheme = localStorage.getItem("theme") || "theme1";
+      setTheme(savedTheme);
+    })();
+  </script>
 </head>
 <body>
   <!-- NAVBAR -->
@@ -247,18 +260,6 @@
 
   <!-- Script principal -->
   <script>
-    // Gestion des thèmes
-    function setTheme(theme) {
-      localStorage.setItem("theme", theme);
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-
-    // Charger thème depuis localStorage
-    (function () {
-      const savedTheme = localStorage.getItem("theme") || "theme1";
-      setTheme(savedTheme);
-    })();
-
     // Burger menu mobile
     document.getElementById('hamburger').addEventListener('click', function () {
       document.getElementById('nav-links').classList.toggle('show');

--- a/hypnose.html
+++ b/hypnose.html
@@ -17,6 +17,19 @@
   <link rel="stylesheet" href="style_form.css" />
   <link rel="stylesheet" href="responsive_main.css" />
   <script src="https://kit.fontawesome.com/2f363087de.js" crossorigin="anonymous"></script>
+  <script>
+    // Gestion des thèmes
+    function setTheme(theme) {
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+
+    // Charger thème depuis localStorage
+    (function () {
+      const savedTheme = localStorage.getItem("theme") || "theme1";
+      setTheme(savedTheme);
+    })();
+  </script>
 </head>
 <body>
   <!-- NAVBAR -->
@@ -423,18 +436,6 @@
 
   <!-- Script principal -->
   <script>
-    // Gestion des thèmes
-    function setTheme(theme) {
-      localStorage.setItem("theme", theme);
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-
-    // Charger thème depuis localStorage
-    (function () {
-      const savedTheme = localStorage.getItem("theme") || "theme1";
-      setTheme(savedTheme);
-    })();
-
     // Burger menu mobile
     document.getElementById('hamburger').addEventListener('click', function () {
       document.getElementById('nav-links').classList.toggle('show');

--- a/index.html
+++ b/index.html
@@ -18,7 +18,19 @@
   <link rel="stylesheet" href="responsive_main.css" />
   <script src="https://kit.fontawesome.com/2f363087de.js" crossorigin="anonymous"></script>
 
+  <script>
+    // Gestion des thèmes
+    function setTheme(theme) {
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+    }
 
+    // Charger thème depuis localStorage
+    (function () {
+      const savedTheme = localStorage.getItem("theme") || "theme1";
+      setTheme(savedTheme);
+    })();
+  </script>
 
 </head>
 <body>
@@ -391,18 +403,6 @@
 
   <!-- Script principal -->
   <script>
-    // Gestion des thèmes
-    function setTheme(theme) {
-      localStorage.setItem("theme", theme);
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-
-    // Charger thème depuis localStorage
-    (function () {
-      const savedTheme = localStorage.getItem("theme") || "theme1";
-      setTheme(savedTheme);
-    })();
-
     // Ouverture / fermeture modal
     function openModal() {
       document.getElementById("feedbackModal").style.display = "block";

--- a/tarifs.html
+++ b/tarifs.html
@@ -17,6 +17,19 @@
   <link rel="stylesheet" href="style_form.css" />
   <link rel="stylesheet" href="responsive_main.css" />
   <script src="https://kit.fontawesome.com/2f363087de.js" crossorigin="anonymous"></script>
+  <script>
+    // Gestion des thèmes
+    function setTheme(theme) {
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+
+    // Charger thème depuis localStorage
+    (function () {
+      const savedTheme = localStorage.getItem("theme") || "theme1";
+      setTheme(savedTheme);
+    })();
+  </script>
 </head>
 <body>
   <!-- NAVBAR -->
@@ -247,18 +260,6 @@
 
   <!-- Script principal -->
   <script>
-    // Gestion des thèmes
-    function setTheme(theme) {
-      localStorage.setItem("theme", theme);
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-
-    // Charger thème depuis localStorage
-    (function () {
-      const savedTheme = localStorage.getItem("theme") || "theme1";
-      setTheme(savedTheme);
-    })();
-
     // Burger menu mobile
     document.getElementById('hamburger').addEventListener('click', function () {
       document.getElementById('nav-links').classList.toggle('show');


### PR DESCRIPTION
The theme-loading script was moved from the end of the body to the head of all HTML pages. This ensures the correct theme is applied before the page is rendered, preventing a flash of the default theme on the first visit.