### PR TITLE
Fix missing images on hypnose.html

### DIFF
--- a/hypnose.html
+++ b/hypnose.html
@@ -175,7 +175,7 @@
           Vous réservez votre créneau comme pour une séance classique. Le rendez-vous se fait via une plateforme sécurisée (Zoom, Teams ou autre outil simple). Comme en cabinet, nous commençons par un temps d’échange pour définir vos objectifs, puis vous êtes guidé pas à pas dans l’expérience hypnotique, depuis votre espace personnel, dans le calme de votre environnement.
       </p>
 
-      <img src="img/visio/ai_session.webp" alt="Un moment d'hypnose guidée à distance" class="column-image" loading="lazy">
+      <img src="img/cabinet/ai_induction.webp" alt="Un moment d'hypnose guidée à distance" class="column-image" loading="lazy">
 
       <h4>Les avantages de l’hypnose à distance</h4>
       <p>
@@ -192,7 +192,7 @@
       <p>
           Que ce soit en cabinet ou en visio, le principe reste le même : vous êtes accompagné avec bienveillance, en toute sécurité, pour mobiliser vos ressources intérieures et avancer vers vos objectifs.
       </p>
-      <img src="img/visio/ai_confiance.webp" alt="Un accompagnement bienveillant même à distance" class="column-image" loading="lazy">
+      <img src="img/cabinet/ai_detente.webp" alt="Un accompagnement bienveillant même à distance" class="column-image" loading="lazy">
   </div>
 </section>
 


### PR DESCRIPTION
Updated hypnose.html to fix two broken image links. The images were pointing to a non-existent 'img/visio/' directory. They now use appropriate replacements from 'img/cabinet/'. Verification with Playwright confirmed that all 17 images on the page load correctly.

---
*PR created automatically by Jules for task [10413572215824214387](https://jules.google.com/task/10413572215824214387) started by @olivierroyo*